### PR TITLE
Adds Python 3.8 and Django 3.1 to tox testing matrix

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -12,17 +12,32 @@ jobs:
         tox_env:
           - py36-django22
           - py36-django30
+          - py36-django31
           - py37-django22
           - py37-django30
+          - py37-django31
+          - py38-django22
+          - py38-django30
+          - py38-django31
         include:
           - python-version: "3.6"
             tox_env: py36-django22
           - python-version: "3.6"
             tox_env: py36-django30
+          - python-version: "3.6"
+            tox_env: py36-django31
           - python-version: "3.7"
             tox_env: py37-django22
           - python-version: "3.7"
             tox_env: py37-django30
+          - python-version: "3.7"
+            tox_env: py37-django31
+          - python-version: "3.8"
+            tox_env: py38-django22
+          - python-version: "3.8"
+            tox_env: py38-django30
+          - python-version: "3.8"
+            tox_env: py38-django31
     steps:
     - name: Install system dependencies
       run: |

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py{36,37}-django{22,30}
+envlist = py{36,37,38}-django{22,30,31}
 
 [testenv]
 commands = coverage run --source django_iam_dbauth --parallel -m pytest {posargs}
 deps =
     django22: Django>=2.2,<2.3
-    django30: Django>=3.0
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
     psycopg2
     mysqlclient
     boto3


### PR DESCRIPTION
Thanks for adding tests for Django 3.0!

This PR expands the testing matrix further to cover Django 3.1 and Python 3.8.